### PR TITLE
Add instance string to prefixes

### DIFF
--- a/models/gb_document/metadata/GbStandardEnterprisePrefix.lutaml
+++ b/models/gb_document/metadata/GbStandardEnterprisePrefix.lutaml
@@ -10,6 +10,6 @@ class GbStandardEnterprisePrefix {
   }
 
   enterpriseCode: Character[3]
-  prefix: String
+  prefix: String = "Q/"
 }
 

--- a/models/gb_document/metadata/GbStandardLocalPrefix.lutaml
+++ b/models/gb_document/metadata/GbStandardLocalPrefix.lutaml
@@ -10,5 +10,5 @@ class GbStandardLocalPrefix {
   }
 
   locationCode: GbLocalCodes
-  prefix: String 
+  prefix: String = "DB"
 }

--- a/models/gb_document/metadata/GbStandardPrefix.lutaml
+++ b/models/gb_document/metadata/GbStandardPrefix.lutaml
@@ -1,4 +1,3 @@
 class GbStandardPrefix{
 
 }
-

--- a/models/gb_document/metadata/GbStandardProfessionalPrefix.lutaml
+++ b/models/gb_document/metadata/GbStandardProfessionalPrefix.lutaml
@@ -9,5 +9,5 @@ class GbStandardProfessionalPrefix {
   }
 
   professionCode: GbProfessionCode
-  prefix: String
+  prefix: String = "ZB"
 }

--- a/models/gb_document/metadata/GbStandardSocialPrefix.lutaml
+++ b/models/gb_document/metadata/GbStandardSocialPrefix.lutaml
@@ -10,5 +10,5 @@ class GbStandardSocialPrefix {
   }
 
   groupCode: Character[3]
-  prefix: String
+  prefix: String = "T/"
 }


### PR DESCRIPTION
In LutaML adding an instance value should be supported:
https://github.com/lutaml/lutaml-uml/blob/master/LUTAML.adoc#value-specification

However, this PR fails because of the instance value. Perhaps a bug in lutaml-uml?