### PR TITLE
metanorma/metanorma-build-scripts#66 Drop ruby 2.4 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #!make
 ifeq ($(OS),Windows_NT)
 SHELL := pwsh -NoProfile
-RM    := Remove-Item -Force
+RM    := Remove-Item -ErrorAction Ignore -Force
 else
 SHELL := /bin/bash
 RM    := rm -f


### PR DESCRIPTION
As title. 

 _Generated by Cimas_.