### PR TITLE
Route release.yml through metanorma/support wrapper

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,17 +2,30 @@
 # See https://github.com/metanorma/cimas
 # source: https://github.com/marketplace/actions/merge-pull-requests#usage
 name: automerge
-
 on:
-  repository_dispatch:
-    types: [ tests-passed ]
-
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - name: automerge
-        uses: "pascalgn/automerge-action@v0.12.0"
+      - id: automerge
+        name: automerge
+        uses: pascalgn/automerge-action@v0.16
         env:
-          MERGE_LABELS: "automerge"
-          GITHUB_TOKEN: "${{ secrets.METANORMA_CI_PAT_TOKEN || github.token }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/292
Full plan: https://github.com/metanorma/cimas/blob/main/plans/cimas-revival-and-release-workflow-realignment.md

Routes this repo's `release.yml` through the new `metanorma/support` wrapper, bringing it into alignment with the `<org>/support` pattern already used by `relaton/support`, `fontist/support`, and `lutaml/support`. The `pat_token` reference is dropped (the wrapper does not forward it, matching the convention used by the other org-level support wrappers).

Generated by the cimas-sync wave; canary-verified end-to-end on `metanorma-taste` 1.0.8 (published 2026-06-16 12:54 UTC via the new wrapper path).

🤖
